### PR TITLE
CI/CD

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,24 @@
+name: Backend
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          dockerfile: backend/Dockerfile
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: docker.pkg.github.com/polycortex/polydodo
+          repository: backend
+          tags: latest

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,45 @@
+name: Mobile
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    working-directory: mobile
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+      - uses: abelfodil/protoc-action@v1
+        with:
+          enable-dart: true
+
+      - run: protoc --proto_path=protos protos/* --dart_out=mobile/lib/protos
+        working-directory: .
+
+      - run: flutter pub get
+
+      - run: flutter test
+
+      - run: flutter build apk
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Android app
+          path: mobile/build/app/outputs/flutter-apk/app-release.apk
+
+      - run: flutter build ios --release --no-codesign
+      - uses: actions/upload-artifact@v2
+        with:
+          name: iOS app
+          path: mobile/build/ios/iphoneos/Runner.app

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,38 @@
+name: Web
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: abelfodil/protoc-action@v1
+      - uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: --cwd web install
+      - run: protoc --proto_path=protos protos/* --js_out=web/src/protos
+      - uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: --cwd web build
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          dockerfile: web/Dockerfile
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: docker.pkg.github.com/polycortex/polydodo
+          repository: web
+          tags: latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu as builder
-RUN apt update && apt install -y protobuf-compiler
+FROM namely/protoc-all as generator
+WORKDIR /
 COPY protos protos
 COPY backend backend
 RUN protoc --proto_path=protos protos/* --python_out=backend/protos 
 
 FROM python
-COPY --from=builder /backend /backend
+COPY --from=generator /backend /backend
 WORKDIR /backend
 RUN pip install -r requirements.txt --no-cache-dir
 ENTRYPOINT ["python", "app.py"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu as builder
+RUN apt update && apt install -y protobuf-compiler
+COPY protos protos
+COPY backend backend
+RUN protoc --proto_path=protos protos/* --python_out=backend/protos 
+
+FROM python
+COPY --from=builder /backend /backend
+WORKDIR /backend
+RUN pip install -r requirements.txt --no-cache-dir
+ENTRYPOINT ["python", "app.py"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,11 @@
-FROM node:14 as builder
-RUN apt update && apt install -y protobuf-compiler
+FROM namely/protoc-all as generator
+WORKDIR /
 COPY protos protos
 COPY web web
-RUN protoc --proto_path=protos protos/* --js_out=web/src/protos 
+RUN protoc --proto_path=protos protos/* --js_out=web/src/protos
+
+FROM node:14 as builder
+COPY --from=generator /web /web
 WORKDIR /web
 RUN yarn install
 RUN yarn build

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14 as builder
+RUN apt update && apt install -y protobuf-compiler
+COPY protos protos
+COPY web web
+RUN protoc --proto_path=protos protos/* --js_out=web/src/protos 
+WORKDIR /web
+RUN yarn install
+RUN yarn build
+
+FROM nginx:alpine
+COPY --from=builder /web/build/ /usr/share/nginx/html


### PR DESCRIPTION
Add CI for:
- `web` (when pushing to master or a PR)
- `mobile` (when pushing to master or a PR)

`backend` is missing unit tests, so no CI for now.

Multi-stage built (to reduce image size) Docker images have been added for:
- `web` (nginx alpine)
- `backend` (python + packages)

Add CD for:
- `web` (docker release when pushing to master)
- `mobile`  (docker release when pushing to master)
- `backend`  (Android and iOS packages when pushing to master or to a PR)

A gRPC GitHub Action https://github.com/abelfodil/protoc-action/ has been created specifically for this project to support cross-platform + Dart plugin protobuf code generation. The Dart plugin is disabled by default and explicitly enabled for `mobile` release to reduce compute time in other stages.

Docker images are available on https://github.com/PolyCortex/polydodo/packages

For now, the iOS and Android bundles can be downloaded from the Mobile workflow page (see https://github.com/PolyCortex/polydodo/actions/runs/240936102 for instance).