### PR TITLE
[Web] Fix URL redirection with github pages

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -13,7 +13,7 @@ import ScrollToTop from 'components/scroll_to_top';
 import Emoji from 'components/emoji';
 
 ReactDOM.render(
-  <BrowserRouter>
+  <BrowserRouter basename={process.env.PUBLIC_URL}>
     <ScrollToTop>
       <Switch>
         <Route exact path="/" render={() => <SleepAnalysis />} />


### PR DESCRIPTION
Problem:
When accessing `polycortex.github.io/polydodo/`, the user gets automatically redirected to `polycortex.github.io/`. When the user then refreshes the page, he gets a 404 error, because the web app is served at the `/polydodo` route, not `/`.

Proposed solution:
Add baseline to the router, as suggested [here](https://github.com/facebook/create-react-app/issues/1765#issuecomment-327615099).