### PR TITLE
Fix stream start prior to bedtime validation bug

### DIFF
--- a/web/src/views/analyze_sleep/upload_form/index.js
+++ b/web/src/views/analyze_sleep/upload_form/index.js
@@ -184,9 +184,8 @@ const UploadForm = () => {
                         innerRef={register({
                           required: 'Date is required.',
                           validate: () => {
-                            const streamStart = new Date(`
-                              ${getValues('stream_start_date')} ${getValues('stream_start_time')}
-                            `);
+                            // prettier-ignore
+                            const streamStart = new Date(`${getValues('stream_start_date')} ${getValues('stream_start_time')}`);
                             const bedTime = new Date(`${getValues('bedtime_date')} ${getValues('bedtime_time')}`);
                             if (streamStart > bedTime) {
                               return 'Stream start must be prior to bedtime.';


### PR DESCRIPTION
Whitespaces(due to autoformat) before and after the relevant information were failing the date parse thus outputting an invalid date and making the validation pass.